### PR TITLE
feat: php version up 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
     phpunit:
@@ -13,7 +13,7 @@ jobs:
             - name: Set up PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 8.2
+                  php-version: 8.3
 
             - name: Install dependencies
               run: composer install --no-progress --no-suggest --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.1",
+        "php": "^8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "guzzlehttp/guzzle": "^7.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7264780bed63aa430be0cd14fcc116ea",
+    "content-hash": "d2cdb83e4ee2b7f538cde4502cd45e60",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -6430,10 +6430,10 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1",
+        "php": "^8.3",
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="tests/bootstrap.php"
-         convertDeprecationsToExceptions="false"
 >
     <php>
         <ini name="display_errors" value="1" />
@@ -23,16 +21,7 @@
         </testsuite>
     </testsuites>
 
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
-
     <extensions>
     </extensions>
 </phpunit>
+


### PR DESCRIPTION
エラー
```
User
1) Test results may not be as expected because the XML configuration file did not pass validation:

  Line 10:
  - Element 'phpunit', attribute 'convertDeprecationsToExceptions': The attribute 'convertDeprecationsToExceptions' is not allowed.

  Line 26:
  - Element 'coverage', attribute 'processUncoveredFiles': The attribute 'processUncoveredFiles' is not allowed.

  Line 27:
  - Element 'include': This element is not expected.

  Line 32:
  - Element 'listeners': This element is not expected.
```

- 'convertDeprecationsToExceptions'属性:

PHPUnitのテスト実行中に発生した非推奨のエラーメッセージを例外として扱うかどうかを制御します。これを設定することで、非推奨のメッセージが例外として報告されるようになります。

- 'processUncoveredFiles'属性:

カバレッジレポートに含まれるべきでない未カバーのファイルを処理するかどうかを制御します。

- 'include'要素:

カバレッジレポートに含まれるべきファイルのディレクトリを指定します。

- 'listeners'要素:

PHPUnitのテスト実行中にリスナーを追加するために使用されます。リスナーは、テスト実行中に特定のイベントをキャッチして処理する機能を提供します。

